### PR TITLE
Add project skeleton for auto mograph bot pipeline

### DIFF
--- a/auto-mograph-bot/.env.example
+++ b/auto-mograph-bot/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for Auto Mograph Bot
+FFMPEG_PATH=/usr/bin/ffmpeg
+SD_API_ENDPOINT=http://localhost:7860
+ANIMATEDIFF_CHECKPOINT=./models/animate-diff/model.ckpt

--- a/auto-mograph-bot/.gitignore
+++ b/auto-mograph-bot/.gitignore
@@ -1,0 +1,31 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.env
+.venv/
+venv/
+
+# IDE
+.vscode/
+.idea/
+
+# Logs
+*.log
+
+# Generated assets
+outputs/
+models/
+assets/sfx/
+assets/fonts/
+
+# OS metadata
+.DS_Store
+Thumbs.db

--- a/auto-mograph-bot/README.md
+++ b/auto-mograph-bot/README.md
@@ -1,0 +1,25 @@
+# Auto Mograph Bot
+
+Auto Mograph Bot 提供一个用于自动化文案生成、图像合成、视频生成与后期处理的流水线脚手架。
+
+## 功能概览
+- 加载 `.env` 与 YAML 配置，统一管理画面参数、模型路径等。
+- 提供文案、风格、标签池管理，支持去重与随机抽样。
+- 结合本地 Stable Diffusion 文本生图与 AnimateDiff/Stable Video Diffusion 等视频模型。
+- 封装常见的 FFmpeg 处理流程，包括拼接、裁切、加速与封面帧合成。
+- 支持竖屏（1080×1920）导出、字幕/水印叠加等后期处理。
+- 通过命令行入口一键跑通生成流水线。
+
+## 快速开始
+1. 复制 `.env.example` 为 `.env`，补充本地资源路径或密钥。
+2. 根据需求修改 `configs/default.yaml`。
+3. 安装依赖：
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. 执行命令行：
+   ```bash
+   python -m src.runner.cli --count 1
+   ```
+
+> **提示**：项目主要用于构建自动化视频宣传/短视频生成工作流，实际模型推理部分需根据本地环境做进一步实现。

--- a/auto-mograph-bot/configs/default.yaml
+++ b/auto-mograph-bot/configs/default.yaml
@@ -1,0 +1,12 @@
+video:
+  width: 1080
+  height: 1920
+  fps: 30
+  duration: 8
+
+model_paths:
+  txt2img: ./models/stable-diffusion
+  img2vid: ./models/animate-diff
+  embeddings: ./models/embeddings
+
+prompt_pool_path: ./configs/prompts.txt

--- a/auto-mograph-bot/configs/prompts.txt
+++ b/auto-mograph-bot/configs/prompts.txt
@@ -1,0 +1,3 @@
+A serene forest with morning mist
+Futuristic neon-lit marketplace at night
+Epic fantasy castle above the clouds

--- a/auto-mograph-bot/pyproject.toml
+++ b/auto-mograph-bot/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "auto-mograph-bot"
+version = "0.1.0"
+description = "Automation pipeline for text-to-image and image-to-video content creation"
+authors = [{ name = "Auto Mograph Team" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "python-dotenv>=1.0.0",
+    "PyYAML>=6.0.1",
+    "pydantic>=2.5",
+    "rich>=13.7",
+    "numpy>=1.24",
+    "opencv-python>=4.9",
+    "ffmpeg-python>=0.2.0",
+    "tqdm>=4.66",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "ruff>=0.1.5",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/auto-mograph-bot/requirements.txt
+++ b/auto-mograph-bot/requirements.txt
@@ -1,0 +1,8 @@
+python-dotenv>=1.0.0
+PyYAML>=6.0.1
+pydantic>=2.5
+rich>=13.7
+numpy>=1.24
+opencv-python>=4.9
+ffmpeg-python>=0.2.0
+tqdm>=4.66

--- a/auto-mograph-bot/src/config.py
+++ b/auto-mograph-bot/src/config.py
@@ -1,0 +1,92 @@
+"""Configuration loader for Auto Mograph Bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, validator
+import yaml
+
+
+class VideoSettings(BaseModel):
+    width: int = 1080
+    height: int = 1920
+    fps: int = 30
+    duration: float = 8.0
+
+    @validator("width", "height", "fps")
+    def validate_positive_int(cls, value: int) -> int:  # noqa: D401
+        """Ensure numeric values are positive."""
+        if value <= 0:
+            raise ValueError("Video dimension values must be positive")
+        return value
+
+    @validator("duration")
+    def validate_duration(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("Video duration must be positive")
+        return value
+
+
+@dataclass
+class ModelPaths:
+    txt2img: Optional[Path] = None
+    img2vid: Optional[Path] = None
+    embeddings: Optional[Path] = None
+
+
+@dataclass
+class PipelineConfig:
+    video: VideoSettings = field(default_factory=VideoSettings)
+    model_paths: ModelPaths = field(default_factory=ModelPaths)
+    prompt_pool_path: Optional[Path] = None
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fp:
+        return yaml.safe_load(fp) or {}
+
+
+def merge_dict(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {**base}
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_config(config_path: Optional[Path] = None, env_path: Optional[Path] = None) -> PipelineConfig:
+    """Load configuration from YAML and `.env` files."""
+
+    if env_path is None:
+        env_path = Path(".env")
+    load_dotenv(dotenv_path=env_path, override=False)
+
+    if config_path is None:
+        config_path = Path("configs/default.yaml")
+
+    data = load_yaml(config_path)
+
+    video_data = data.get("video", {})
+    model_data = data.get("model_paths", {})
+    extra = {key: value for key, value in data.items() if key not in {"video", "model_paths"}}
+
+    video_settings = VideoSettings(**video_data)
+    model_paths = ModelPaths(**{k: Path(v) if v else None for k, v in model_data.items()})
+
+    return PipelineConfig(
+        video=video_settings,
+        model_paths=model_paths,
+        prompt_pool_path=Path(data["prompt_pool_path"]) if data.get("prompt_pool_path") else None,
+        extra=extra,
+    )
+
+
+__all__ = ["PipelineConfig", "VideoSettings", "ModelPaths", "load_config"]

--- a/auto-mograph-bot/src/prompts/__init__.py
+++ b/auto-mograph-bot/src/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt management utilities."""
+
+from .pool import PromptPool
+
+__all__ = ["PromptPool"]

--- a/auto-mograph-bot/src/prompts/pool.py
+++ b/auto-mograph-bot/src/prompts/pool.py
@@ -1,0 +1,67 @@
+"""Prompt pool helpers for sampling unique combinations."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Sequence, Set
+
+
+@dataclass
+class PromptPool:
+    """Maintain prompt candidates and support deduplicated sampling."""
+
+    texts: List[str] = field(default_factory=list)
+    styles: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    _used_hashes: Set[str] = field(default_factory=set, init=False, repr=False)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "PromptPool":
+        lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        return cls(texts=lines)
+
+    def extend_texts(self, values: Iterable[str]) -> None:
+        self.texts.extend(filter(None, map(str.strip, values)))
+
+    def extend_styles(self, values: Iterable[str]) -> None:
+        self.styles.extend(filter(None, map(str.strip, values)))
+
+    def extend_tags(self, values: Iterable[str]) -> None:
+        self.tags.extend(filter(None, map(str.strip, values)))
+
+    def clear_usage(self) -> None:
+        self._used_hashes.clear()
+
+    def random_choice(self, count: int = 1) -> List[str]:
+        if not self.texts:
+            raise ValueError("PromptPool has no text entries")
+        return random.sample(self.texts, k=min(count, len(self.texts)))
+
+    def sample_combo(self) -> str:
+        """Combine text, style and tags with deduplication."""
+
+        text = random.choice(self.texts) if self.texts else ""
+        style = random.choice(self.styles) if self.styles else ""
+        tag_list = random.sample(self.tags, k=min(len(self.tags), 3)) if self.tags else []
+
+        parts: Sequence[str] = [text, style, ", ".join(tag_list)]
+        combo = " | ".join(filter(None, parts))
+        combo_hash = combo.lower()
+
+        attempts = 0
+        while combo_hash in self._used_hashes and attempts < 5:
+            text = random.choice(self.texts)
+            style = random.choice(self.styles) if self.styles else style
+            tag_list = random.sample(self.tags, k=min(len(self.tags), 3)) if self.tags else tag_list
+            parts = [text, style, ", ".join(tag_list)]
+            combo = " | ".join(filter(None, parts))
+            combo_hash = combo.lower()
+            attempts += 1
+
+        self._used_hashes.add(combo_hash)
+        return combo
+
+
+__all__ = ["PromptPool"]

--- a/auto-mograph-bot/src/runner/__init__.py
+++ b/auto-mograph-bot/src/runner/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline runner utilities."""
+
+from .job import GenerationJob
+
+__all__ = ["GenerationJob"]

--- a/auto-mograph-bot/src/runner/cli.py
+++ b/auto-mograph-bot/src/runner/cli.py
@@ -1,0 +1,32 @@
+"""Command line entry point for Auto Mograph Bot."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rich.console import Console
+
+from .job import GenerationJob
+
+console = Console()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Auto Mograph Bot pipeline")
+    parser.add_argument("--config", type=Path, default=Path("configs/default.yaml"), help="Path to YAML config")
+    parser.add_argument("--count", type=int, default=1, help="Number of jobs to run")
+    parser.add_argument("--output", type=Path, default=Path("outputs"), help="Output directory")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    job = GenerationJob.from_config(args.config)
+    for index in range(args.count):
+        console.rule(f"Job {index + 1}/{args.count}")
+        job.run(args.output / f"job_{index + 1}")
+
+
+if __name__ == "__main__":
+    main()

--- a/auto-mograph-bot/src/runner/job.py
+++ b/auto-mograph-bot/src/runner/job.py
@@ -1,0 +1,59 @@
+"""High level orchestration for generation jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+
+from ..config import PipelineConfig, load_config
+from ..prompts import PromptPool
+from ..sd import Img2VidGenerator, Txt2ImgGenerator
+from ..video import adapt_vertical
+
+console = Console()
+
+
+@dataclass
+class GenerationJob:
+    """Represents a single text-to-video pipeline run."""
+
+    config: PipelineConfig
+    prompt_pool: PromptPool
+    txt2img: Txt2ImgGenerator
+    img2vid: Img2VidGenerator
+
+    @classmethod
+    def from_config(cls, config_path: Optional[Path] = None) -> "GenerationJob":
+        config = load_config(config_path)
+        prompt_pool = PromptPool()
+        if config.prompt_pool_path and config.prompt_pool_path.exists():
+            prompt_pool.extend_texts(config.prompt_pool_path.read_text(encoding="utf-8").splitlines())
+        else:
+            prompt_pool.extend_texts(["A cyberpunk cityscape at dusk"])
+
+        txt2img = Txt2ImgGenerator(model_path=config.model_paths.txt2img)
+        img2vid = Img2VidGenerator(model_path=config.model_paths.img2vid)
+
+        return cls(config=config, prompt_pool=prompt_pool, txt2img=txt2img, img2vid=img2vid)
+
+    def run(self, output_dir: Path) -> Path:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        prompt = self.prompt_pool.sample_combo()
+        console.log(f"Using prompt: {prompt}")
+
+        image_path = output_dir / "frame.txt"
+        video_stub = output_dir / "animation.txt"
+        final_video = output_dir / "final.txt"
+
+        self.txt2img.generate(prompt, image_path)
+        self.img2vid.generate(image_path, video_stub, fps=self.config.video.fps)
+        adapt_vertical(video_stub, final_video, resolution=(self.config.video.width, self.config.video.height))
+
+        console.log(f"Job completed, output at {final_video}")
+        return final_video
+
+
+__all__ = ["GenerationJob"]

--- a/auto-mograph-bot/src/sd/__init__.py
+++ b/auto-mograph-bot/src/sd/__init__.py
@@ -1,0 +1,6 @@
+"""Stable Diffusion related interfaces."""
+
+from .txt2img import Txt2ImgGenerator
+from .img2vid import Img2VidGenerator
+
+__all__ = ["Txt2ImgGenerator", "Img2VidGenerator"]

--- a/auto-mograph-bot/src/sd/img2vid.py
+++ b/auto-mograph-bot/src/sd/img2vid.py
@@ -1,0 +1,36 @@
+"""Image to video generation stub implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+
+console = Console()
+
+
+class Img2VidGenerator:
+    """AnimateDiff / Stable Video Diffusion wrapper stub."""
+
+    def __init__(self, model_path: Optional[Path] = None, motion_module: Optional[Path] = None) -> None:
+        self.model_path = model_path
+        self.motion_module = motion_module
+
+    def generate(self, image_path: Path, output_path: Path, num_frames: int = 24, fps: int = 30) -> Path:
+        """Simulate turning an image into a short video clip."""
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = [
+            f"Source image: {image_path}",
+            f"Frames: {num_frames}",
+            f"FPS: {fps}",
+            f"Model path: {self.model_path}",
+            f"Motion module: {self.motion_module}",
+        ]
+        output_path.write_text("\n".join(metadata), encoding="utf-8")
+        console.log(f"[blue]Generated[/blue] placeholder video at {output_path}")
+        return output_path
+
+
+__all__ = ["Img2VidGenerator"]

--- a/auto-mograph-bot/src/sd/txt2img.py
+++ b/auto-mograph-bot/src/sd/txt2img.py
@@ -1,0 +1,39 @@
+"""Text to image generation stub implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from rich.console import Console
+
+console = Console()
+
+
+class Txt2ImgGenerator:
+    """Interface for Stable Diffusion text-to-image generation."""
+
+    def __init__(self, model_path: Optional[Path] = None, sampler: str = "ddim") -> None:
+        self.model_path = model_path
+        self.sampler = sampler
+
+    def generate(self, prompt: str, output_path: Path, options: Optional[Dict[str, float]] = None) -> Path:
+        """Generate an image for the given prompt.
+
+        This stub simulates generation by writing prompt metadata to a text file.
+        Replace with diffusers or WebUI API calls as needed.
+        """
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        content = [
+            f"Prompt: {prompt}",
+            f"Sampler: {self.sampler}",
+            f"Model path: {self.model_path}",
+            f"Options: {options or {}}",
+        ]
+        output_path.write_text("\n".join(content), encoding="utf-8")
+        console.log(f"[green]Generated[/green] placeholder image at {output_path}")
+        return output_path
+
+
+__all__ = ["Txt2ImgGenerator"]

--- a/auto-mograph-bot/src/video/__init__.py
+++ b/auto-mograph-bot/src/video/__init__.py
@@ -1,0 +1,12 @@
+"""Video post-processing utilities."""
+
+from .ffmpeg_utils import concat_videos, ensure_ffmpeg_available
+from .postprocess import apply_watermark, add_subtitles, adapt_vertical
+
+__all__ = [
+    "concat_videos",
+    "ensure_ffmpeg_available",
+    "apply_watermark",
+    "add_subtitles",
+    "adapt_vertical",
+]

--- a/auto-mograph-bot/src/video/ffmpeg_utils.py
+++ b/auto-mograph-bot/src/video/ffmpeg_utils.py
@@ -1,0 +1,59 @@
+"""Utility helpers to interact with FFmpeg."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, List
+
+from rich.console import Console
+
+console = Console()
+
+
+def ensure_ffmpeg_available() -> None:
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError("FFmpeg binary not found. Please install FFmpeg and ensure it is on PATH.")
+
+
+def run_ffmpeg(command: List[str]) -> None:
+    ensure_ffmpeg_available()
+    console.log("Running FFmpeg command", " ".join(command))
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        console.log(result.stderr)
+        raise RuntimeError(f"FFmpeg command failed with code {result.returncode}")
+    console.log(result.stdout)
+
+
+def concat_videos(inputs: Iterable[Path], output: Path, reencode: bool = False) -> Path:
+    """Concatenate videos using FFmpeg."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    file_list = output.with_suffix(".txt")
+    with file_list.open("w", encoding="utf-8") as fp:
+        for item in inputs:
+            fp.write(f"file '{item.as_posix()}'\n")
+
+    command = [
+        "ffmpeg",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(file_list),
+    ]
+    if reencode:
+        command.extend(["-c:v", "libx264", "-preset", "medium", "-crf", "18"])
+    else:
+        command.extend(["-c", "copy"])
+    command.append(str(output))
+
+    run_ffmpeg(command)
+    file_list.unlink(missing_ok=True)
+    return output
+
+
+__all__ = ["concat_videos", "ensure_ffmpeg_available"]

--- a/auto-mograph-bot/src/video/postprocess.py
+++ b/auto-mograph-bot/src/video/postprocess.py
@@ -1,0 +1,41 @@
+"""Simple post-processing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+
+console = Console()
+
+
+def adapt_vertical(input_path: Path, output_path: Path, resolution: tuple[int, int] = (1080, 1920)) -> Path:
+    """Placeholder vertical adaptation."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        f"Adapted {input_path} to vertical resolution {resolution[0]}x{resolution[1]}",
+        encoding="utf-8",
+    )
+    console.log(f"Adapted video saved to {output_path}")
+    return output_path
+
+
+def add_subtitles(video_path: Path, subtitle_path: Path, output_path: Optional[Path] = None) -> Path:
+    if output_path is None:
+        output_path = video_path.with_name(f"{video_path.stem}_subtitled{video_path.suffix}")
+    output_path.write_text(f"Subtitles from {subtitle_path} applied to {video_path}", encoding="utf-8")
+    console.log(f"Subtitled video saved to {output_path}")
+    return output_path
+
+
+def apply_watermark(video_path: Path, watermark_path: Path, output_path: Optional[Path] = None) -> Path:
+    if output_path is None:
+        output_path = video_path.with_name(f"{video_path.stem}_watermarked{video_path.suffix}")
+    output_path.write_text(f"Watermark {watermark_path} applied to {video_path}", encoding="utf-8")
+    console.log(f"Watermarked video saved to {output_path}")
+    return output_path
+
+
+__all__ = ["adapt_vertical", "add_subtitles", "apply_watermark"]


### PR DESCRIPTION
## Summary
- add initial project layout for the Auto Mograph Bot pipeline including configuration, prompts, and runner modules
- include Stable Diffusion stubs and video utilities for future integration work
- provide dependency metadata, sample configuration, and environment templates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cff272b88328945673e9d4ddcf94