### PR TITLE
feat: add structured retry logging for generation pipeline

### DIFF
--- a/auto-mograph-bot/configs/default.yaml
+++ b/auto-mograph-bot/configs/default.yaml
@@ -85,3 +85,14 @@ runtime:
 postprocess:
   subtitle: false
   watermark: false
+
+retry:
+  max_attempts: 3
+  backoff_factor: 2
+  jitter_ms: 150
+  ffmpeg:
+    enabled: true
+    retryable_exit_codes: [1, 255]
+
+logging:
+  jsonl_path: "outputs/logs/pipeline.jsonl"

--- a/auto-mograph-bot/docs/stability_README.md
+++ b/auto-mograph-bot/docs/stability_README.md
@@ -1,0 +1,64 @@
+# 稳定性与可观测性说明
+
+本文档介绍 Stable Diffusion/FFmpeg 调用的重试策略、错误分类及结构化日志字段，帮助在网络抖动或依赖异常时快速定位问题。
+
+## 退避重试策略
+
+- **指数退避**：首轮尝试失败后，等待时间按 `delay *= backoff_factor` 成长，默认 `1s → 2s → 4s`。
+- **随机抖动**：为避免雪崩，在每次等待前额外添加 `0 ~ jitter_ms` 的随机抖动（毫秒）。
+- **最大尝试次数**：`retry.max_attempts` 控制包含首次调用在内的总尝试次数，默认 3 次。
+- **可配置性**：上述参数均可在 `configs/default.yaml` 的 `retry` 段中修改；FFmpeg 可通过 `retry.ffmpeg.enabled` 和 `retry.ffmpeg.retryable_exit_codes` 进一步限制重试范围。
+
+## 错误分类
+
+### Stable Diffusion（文本生图/图生视频）
+
+| 分类 | 触发条件 | 建议 hint |
+| --- | --- | --- |
+| `timeout` | 调用超时或响应中包含 `timeout` | 检查网络连通性或增加超时时间 |
+| `conn_error` | 无法建立连接、DNS 失败、连接拒绝 | 确认 SD WebUI 地址/端口可达 |
+| `http_5xx` | WebUI 返回 5xx | 检查 WebUI 服务端日志并重启 |
+| `rate_limited` | 返回 429 | 降低并发或增加请求间隔 |
+| `bad_request` | WebUI 返回 4xx（非 401/429） | 检查提示词和参数合法性 |
+| `auth_error` | 401/鉴权失败 | 核对 Token 或鉴权配置 |
+| `oom` | 消息含 `out of memory`/`CUDA` | 降低分辨率或 batch size |
+| `unknown` | 其余未识别异常 | 查看 `pipeline.jsonl` 中的 traceback |
+
+### FFmpeg 执行
+
+| 分类 | 触发条件 | 建议 hint |
+| --- | --- | --- |
+| `no_ffmpeg` | 无可执行文件或 `command not found` | 安装 FFmpeg 并添加到 PATH |
+| `file_not_found` | `No such file or directory` | 核对输入/输出路径 |
+| `disk_full` | `No space left on device` 等 | 清理磁盘或切换输出目录 |
+| `permission` | `Permission denied` | 检查文件/目录权限 |
+| `codec_missing` | `codec not found`/`unknown encoder` | 安装编解码器或修改参数 |
+| `resource_busy` | `resource busy`/`temporarily unavailable` | 确保目标文件未被占用 |
+| `broken_pipe` | `Broken pipe`/`EPIPE` | 检查上游数据管道 |
+| `timeout` | 包含 `timed out` | 检查 IO/网络或提高超时 |
+| `io_error` | `Input/output error` | 检查磁盘健康状况 |
+| `unknown` | 其他错误 | 查看完整 stderr |
+
+配置中列出的退出码（默认 `1`、`255`）或分类为 `timeout`/`resource_busy`/`broken_pipe`/`io_error` 时会触发自动重试。
+
+## 结构化日志 (`outputs/logs/pipeline.jsonl`)
+
+每行是一条 JSON 记录，核心字段说明：
+
+- `event`：事件名称，如 `sd_call_start`、`ffmpeg_fail`、`upload_success`。
+- `ts`：UNIX 时间戳（秒）。
+- `elapsed_ms`：事件耗时（毫秒），若适用。
+- `category`：错误分类（仅失败事件）。
+- `hint`：针对错误的修复建议。
+- `command`/`fn`/`provider` 等上下文字段：指示命令、函数名或上传渠道。
+- `traceback`：异常堆栈，仅在 `log_exception` 中出现。
+- `stderr`：FFmpeg 失败时截断后的标准错误文本。
+
+### 快速排查建议
+
+1. **定位异常**：搜索 `ffmpeg_fail`、`sd_call_fail` 或 `upload_fail`，查看 `category` 与 `hint`。
+2. **追踪重试**：同一事件的 `attempt` 与 `max_attempts` 可评估重试次数。
+3. **对比耗时**：`elapsed_ms` 帮助确认问题集中在哪个环节。
+4. **关联上下文**：结合 `seed`、`backend`、`file` 等字段将日志与具体任务关联。
+
+合理配置重试与观察日志可以显著提升链路在网络抖动、磁盘异常等情况下的自愈能力与可诊断性。

--- a/auto-mograph-bot/src/logging/__init__.py
+++ b/auto-mograph-bot/src/logging/__init__.py
@@ -1,5 +1,17 @@
 """日志工具模块。"""
 
-from .structlog import get_logger, log_resource_snapshot
+from .structlog import (
+    get_logger,
+    init_logging,
+    log_event,
+    log_exception,
+    log_resource_snapshot,
+)
 
-__all__ = ["get_logger", "log_resource_snapshot"]
+__all__ = [
+    "get_logger",
+    "init_logging",
+    "log_event",
+    "log_exception",
+    "log_resource_snapshot",
+]

--- a/auto-mograph-bot/src/logging/structlog.py
+++ b/auto-mograph-bot/src/logging/structlog.py
@@ -1,15 +1,89 @@
-"""结构化日志辅助工具。"""
+"""结构化日志辅助工具，负责输出 JSONL 事件。"""
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Dict
+import os
+import threading
+import time
+import traceback
+from typing import Any, Dict, Optional
 
 _DEFAULT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_FALLBACK_LOGGER_NAME = "auto_mograph"
+_WRITE_LOCK = threading.Lock()
+_LOG_PATH: Optional[str] = None
 
 
-def get_logger(name: str = "auto_mograph") -> logging.Logger:
-    """返回带有标准输出处理器的日志记录器。"""
+def _ensure_fallback_logger() -> logging.Logger:
+    """确保存在一个标准输出日志记录器，用于未初始化时的回退。"""
+
+    logger = logging.getLogger(_FALLBACK_LOGGER_NAME)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(_DEFAULT_FORMAT))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+def _json_default(value: Any) -> Any:
+    """为 JSON 序列化提供兜底转换。"""
+
+    if isinstance(value, Exception):
+        return str(value)
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:  # noqa: BLE001
+            return str(value)
+    return str(value)
+
+
+def init_logging(jsonl_path: str) -> None:
+    """初始化结构化日志输出位置。"""
+
+    global _LOG_PATH
+    if not jsonl_path:
+        _LOG_PATH = None
+        return
+    directory = os.path.dirname(jsonl_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    _LOG_PATH = jsonl_path
+
+
+def _write_record(record: Dict[str, Any]) -> None:
+    """写入单行 JSON 记录，必要时退回到标准日志。"""
+
+    if _LOG_PATH:
+        line = json.dumps(record, ensure_ascii=False, default=_json_default)
+        with _WRITE_LOCK:
+            with open(_LOG_PATH, "a", encoding="utf-8") as fp:
+                fp.write(line + "\n")
+    else:
+        fallback = _ensure_fallback_logger()
+        fallback.info(json.dumps(record, ensure_ascii=False, default=_json_default))
+
+
+def log_event(event: str, **kwargs: Any) -> None:
+    """输出结构化事件日志。"""
+
+    record: Dict[str, Any] = {"event": event, "ts": time.time()}
+    record.update(kwargs)
+    _write_record(record)
+
+
+def log_exception(event: str, err: Exception, **kwargs: Any) -> None:
+    """输出包含异常信息与堆栈的结构化日志。"""
+
+    trace = traceback.format_exc()
+    log_event(event, error=str(err), traceback=trace, **kwargs)
+
+
+def get_logger(name: str = _FALLBACK_LOGGER_NAME) -> logging.Logger:
+    """兼容旧接口，返回标准输出日志记录器。"""
 
     logger = logging.getLogger(name)
     if not logger.handlers:
@@ -27,17 +101,33 @@ def log_resource_snapshot(
     requested: int,
     effective: int,
 ) -> None:
-    """输出资源快照信息。"""
+    """输出资源快照信息，同时写入结构化日志。"""
 
-    logger.info(
-        "Resource snapshot | GPU=%s | total=%sMB | free=%sMB | CPU cores=%s | requested=%s | effective=%s",
-        gpu_info.get("name", "unknown"),
-        gpu_info.get("total", 0),
-        gpu_info.get("free", 0),
-        cpu_cores,
-        requested,
-        effective,
+    message = (
+        "Resource snapshot | GPU=%s | total=%sMB | free=%sMB | CPU cores=%s | requested=%s | effective=%s"
+        % (
+            gpu_info.get("name", "unknown"),
+            gpu_info.get("total", 0),
+            gpu_info.get("free", 0),
+            cpu_cores,
+            requested,
+            effective,
+        )
+    )
+    logger.info(message)
+    log_event(
+        "resource_snapshot",
+        gpu=gpu_info,
+        cpu_cores=cpu_cores,
+        requested_concurrency=requested,
+        effective_concurrency=effective,
     )
 
 
-__all__ = ["get_logger", "log_resource_snapshot"]
+__all__ = [
+    "get_logger",
+    "init_logging",
+    "log_event",
+    "log_exception",
+    "log_resource_snapshot",
+]

--- a/auto-mograph-bot/src/sd/txt2img.py
+++ b/auto-mograph-bot/src/sd/txt2img.py
@@ -2,18 +2,156 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import random
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import httpx
 from rich.console import Console
 
 from ..config import PipelineConfig
+from ..logging.structlog import log_event, log_exception
 
 console = Console()
+
+_RETRY_CFG: Dict[str, Any] = {"max_attempts": 1, "backoff_factor": 1.0, "jitter_ms": 0}
+
+
+def configure_sd_retry(settings: Any) -> None:
+    """更新默认的 SD 调用重试配置。"""
+
+    global _RETRY_CFG
+    if settings is None:
+        return
+    data: Dict[str, Any]
+    if hasattr(settings, "model_dump"):
+        data = settings.model_dump()
+    elif isinstance(settings, dict):
+        data = settings
+    else:
+        data = dict(settings)
+    updated = {
+        "max_attempts": int(data.get("max_attempts", _RETRY_CFG["max_attempts"])),
+        "backoff_factor": float(data.get("backoff_factor", _RETRY_CFG["backoff_factor"])),
+        "jitter_ms": int(data.get("jitter_ms", _RETRY_CFG["jitter_ms"])),
+    }
+    _RETRY_CFG = updated
+    log_event("retry_config_updated", component="sd", config=updated)
+
+
+def get_retry_cfg() -> Dict[str, Any]:
+    """返回当前的重试配置副本。"""
+
+    return dict(_RETRY_CFG)
+
+
+def _normalize_retry_cfg(raw: Optional[Any]) -> Dict[str, Any]:
+    if raw is None:
+        return get_retry_cfg()
+    if hasattr(raw, "model_dump"):
+        raw = raw.model_dump()
+    if isinstance(raw, dict):
+        cfg = raw
+    else:
+        cfg = dict(raw)
+    return {
+        "max_attempts": max(1, int(cfg.get("max_attempts", _RETRY_CFG["max_attempts"]))),
+        "backoff_factor": max(1.0, float(cfg.get("backoff_factor", _RETRY_CFG["backoff_factor"]))),
+        "jitter_ms": max(0, int(cfg.get("jitter_ms", _RETRY_CFG["jitter_ms"]))),
+    }
+
+
+def classify_sd_error(err: Exception) -> Tuple[str, str]:
+    """根据异常内容给出错误类别与修复建议。"""
+
+    message = str(err).lower()
+    if isinstance(err, httpx.TimeoutException) or "timeout" in message:
+        return "timeout", "检查网络连通性或适当提高超时时间"
+    if isinstance(err, httpx.ConnectError) or "connection refused" in message:
+        return "conn_error", "确认 SD WebUI 服务已启动且地址配置正确"
+    if isinstance(err, httpx.HTTPStatusError):
+        status = err.response.status_code
+        if status == 429:
+            return "rate_limited", "降低并发或延长请求间隔"
+        if 500 <= status < 600:
+            return "http_5xx", "检查 WebUI 服务端日志或重启服务"
+        if 400 <= status < 500:
+            return "bad_request", "校验提示词与参数是否符合接口要求"
+    if isinstance(err, httpx.RequestError):
+        return "conn_error", "检查网络代理、防火墙或服务监听端口"
+    if "out of memory" in message or "cuda" in message and "memory" in message:
+        return "oom", "降低生成分辨率或减少批量大小"
+    if "unauthorized" in message or "401" in message:
+        return "auth_error", "确认 WebUI Token 或鉴权配置是否有效"
+    return "unknown", "查看 pipeline.jsonl 中的 traceback 以进一步排查"
+
+
+def with_retry(fn):  # type: ignore[no-untyped-def]
+    """为 SD 调用增加指数退避与结构化日志。"""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        cfg = _normalize_retry_cfg(kwargs.pop("_retry_cfg", None))
+        log_ctx = kwargs.pop("_log_ctx", {})
+        attempts = max(1, int(cfg.get("max_attempts", 1)))
+        backoff = max(1.0, float(cfg.get("backoff_factor", 1.0)))
+        jitter_ms = max(0, int(cfg.get("jitter_ms", 0)))
+        delay = 1.0
+        for attempt in range(1, attempts + 1):
+            log_event(
+                "sd_call_start",
+                fn=fn.__name__,
+                attempt=attempt,
+                max_attempts=attempts,
+                **log_ctx,
+            )
+            start = time.time()
+            try:
+                result = fn(*args, **kwargs)
+                elapsed_ms = int((time.time() - start) * 1000)
+                log_event(
+                    "sd_call_success",
+                    fn=fn.__name__,
+                    attempt=attempt,
+                    elapsed_ms=elapsed_ms,
+                    **log_ctx,
+                )
+                return result
+            except Exception as err:  # noqa: BLE001
+                elapsed_ms = int((time.time() - start) * 1000)
+                category, hint = classify_sd_error(err)
+                log_exception(
+                    "sd_call_fail",
+                    err,
+                    fn=fn.__name__,
+                    attempt=attempt,
+                    elapsed_ms=elapsed_ms,
+                    category=category,
+                    hint=hint,
+                    **log_ctx,
+                )
+                if attempt >= attempts:
+                    raise
+                jitter = random.randint(0, jitter_ms) / 1000.0 if jitter_ms else 0.0
+                sleep_seconds = delay + jitter
+                log_event(
+                    "sd_call_retry",
+                    fn=fn.__name__,
+                    attempt=attempt,
+                    next_delay_ms=int(sleep_seconds * 1000),
+                    category=category,
+                    hint=hint,
+                    **log_ctx,
+                )
+                time.sleep(sleep_seconds)
+                delay *= backoff
+        raise RuntimeError("SD call exhausted all retry attempts")
+
+    return wrapper
 
 
 @dataclass
@@ -34,9 +172,11 @@ class BaseTxt2ImgBackend:
 class DiffusersTxt2ImgBackend(BaseTxt2ImgBackend):
     """使用 diffusers 本地推理的占位实现。"""
 
-    def __init__(self, model_path: Optional[Path]) -> None:
+    def __init__(self, model_path: Optional[Path], retry_cfg: Optional[Dict[str, Any]] = None) -> None:
         self.model_path = model_path
+        self.retry_cfg = _normalize_retry_cfg(retry_cfg)
 
+    @with_retry
     def generate(self, prompt: str, negative_prompt: str, output_path: Path, seed: int) -> Txt2ImgResult:
         """占位逻辑：写入元数据，实际项目应替换为 diffusers 推理。"""
 
@@ -49,16 +189,24 @@ class DiffusersTxt2ImgBackend(BaseTxt2ImgBackend):
         }
         output_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
         console.log(f"[green]Diffusers 后端写入占位图片：[/green]{output_path}")
+        log_event(
+            "sd_diffusers_placeholder",
+            backend="diffusers",
+            output=str(output_path),
+            seed=seed,
+        )
         return Txt2ImgResult(image_path=output_path, seed=seed)
 
 
 class WebUITxt2ImgBackend(BaseTxt2ImgBackend):
     """对接 Stable Diffusion WebUI 的 HTTP API。"""
 
-    def __init__(self, base_url: str, token: Optional[str] = None) -> None:
+    def __init__(self, base_url: str, token: Optional[str] = None, retry_cfg: Optional[Dict[str, Any]] = None) -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
+        self.retry_cfg = _normalize_retry_cfg(retry_cfg)
 
+    @with_retry
     def generate(self, prompt: str, negative_prompt: str, output_path: Path, seed: int) -> Txt2ImgResult:
         payload: Dict[str, object] = {
             "prompt": prompt,
@@ -88,6 +236,12 @@ class WebUITxt2ImgBackend(BaseTxt2ImgBackend):
         data = response.json()
         output_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
         console.log(f"[green]已保存 WebUI 返回占位数据：[/green]{output_path}")
+        log_event(
+            "sd_webui_response_saved",
+            backend="webui",
+            output=str(output_path),
+            seed=seed,
+        )
         return Txt2ImgResult(image_path=output_path, seed=seed)
 
 
@@ -100,10 +254,16 @@ class Txt2ImgGenerator:
         if sd_config.backend == "webui" and not sd_config.webui_url:
             raise ValueError("配置为 WebUI 后端时必须提供 SD_WEBUI_URL 或 sd.webui_url")
         self.backend: BaseTxt2ImgBackend
+        retry_cfg = get_retry_cfg()
         if sd_config.backend == "webui":
-            self.backend = WebUITxt2ImgBackend(sd_config.webui_url or "http://127.0.0.1:7860", sd_config.webui_token)
+            self.backend = WebUITxt2ImgBackend(
+                sd_config.webui_url or "http://127.0.0.1:7860",
+                sd_config.webui_token,
+                retry_cfg,
+            )
         else:
-            self.backend = DiffusersTxt2ImgBackend(sd_config.model_path)
+            self.backend = DiffusersTxt2ImgBackend(sd_config.model_path, retry_cfg)
+        self.retry_cfg = retry_cfg
 
     def generate(self, prompt: str, negative_prompt: str, output_path: Path, seed: Optional[int] = None) -> Txt2ImgResult:
         """执行文本生图并返回结果。"""
@@ -122,9 +282,25 @@ class Txt2ImgGenerator:
                 encoding="utf-8",
             )
             console.log(f"[yellow]Dry-run 模式下仅写入文案信息：[/yellow]{output_path}")
+            log_event(
+                "sd_dry_run",
+                backend=self.config.sd.backend,
+                output=str(output_path),
+                seed=final_seed,
+            )
             return Txt2ImgResult(image_path=output_path, seed=final_seed)
 
-        return self.backend.generate(prompt=prompt, negative_prompt=negative_prompt, output_path=output_path, seed=final_seed)
+        return self.backend.generate(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            output_path=output_path,
+            seed=final_seed,
+            _retry_cfg=self.retry_cfg,
+            _log_ctx={
+                "backend": self.config.sd.backend,
+                "seed": final_seed,
+            },
+        )
 
 
-__all__ = ["Txt2ImgGenerator", "Txt2ImgResult"]
+__all__ = ["Txt2ImgGenerator", "Txt2ImgResult", "configure_sd_retry", "with_retry", "get_retry_cfg"]

--- a/auto-mograph-bot/src/uploader/router.py
+++ b/auto-mograph-bot/src/uploader/router.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 from rich.console import Console
 
 from ..config import PipelineConfig
+from ..logging.structlog import log_event, log_exception
 from .interfaces import DraftResult, DummyUploader, UploadMetadata, Uploader
 from .providers.android_appium import AndroidAppiumUploader
 from .providers.tiktok_like_api import TikTokLikeAPIDraftUploader
@@ -32,12 +34,45 @@ def upload_video(config: PipelineConfig, video_path: Path, metadata: UploadMetad
     """统一上传入口：准备元数据并执行上传。"""
 
     uploader = build_uploader(config)
+    provider_name = getattr(uploader, "provider_name", config.uploader.provider or "unknown")
+    start = time.time()
+    log_event(
+        "upload_start",
+        platform=config.uploader.target,
+        provider=provider_name,
+        file=str(video_path),
+    )
     prepared = uploader.prepare_metadata(video_path, metadata)
+    log_event(
+        "upload_metadata_prepared",
+        platform=config.uploader.target,
+        provider=provider_name,
+        file=str(video_path),
+    )
     try:
-        return uploader.upload(video_path, prepared)
+        result = uploader.upload(video_path, prepared)
+        elapsed_ms = int((time.time() - start) * 1000)
+        log_event(
+            "upload_success",
+            platform=config.uploader.target,
+            provider=provider_name,
+            file=str(video_path),
+            elapsed_ms=elapsed_ms,
+            draft_url=result.draft_url,
+        )
+        return result
     except Exception as exc:  # noqa: BLE001
         console.log(f"[red]上传流程出现异常：{exc}[/red]")
-        return DraftResult(success=False, message=str(exc), provider=getattr(uploader, "provider_name", "unknown"))
+        elapsed_ms = int((time.time() - start) * 1000)
+        log_exception(
+            "upload_fail",
+            exc,
+            platform=config.uploader.target,
+            provider=provider_name,
+            file=str(video_path),
+            elapsed_ms=elapsed_ms,
+        )
+        return DraftResult(success=False, message=str(exc), provider=provider_name)
 
 
 __all__ = ["build_uploader", "upload_video"]

--- a/auto-mograph-bot/src/video/ffmpeg_utils.py
+++ b/auto-mograph-bot/src/video/ffmpeg_utils.py
@@ -3,14 +3,94 @@
 from __future__ import annotations
 
 import os
+import random
 import shutil
 import subprocess
+import time
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from rich.console import Console
 
+from ..logging.structlog import log_event, log_exception
+
 console = Console()
+
+_FFMPEG_RETRY_CFG: Dict[str, object] = {
+    "max_attempts": 1,
+    "backoff_factor": 1.0,
+    "jitter_ms": 0,
+    "enabled": False,
+    "retryable_exit_codes": [],
+}
+
+
+def configure_ffmpeg_retry(settings: object) -> None:
+    """同步配置中的 FFmpeg 重试策略。"""
+
+    global _FFMPEG_RETRY_CFG
+    if settings is None:
+        return
+    if hasattr(settings, "model_dump"):
+        data = settings.model_dump()
+    elif isinstance(settings, dict):
+        data = settings
+    else:
+        data = dict(settings)
+    ffmpeg_cfg = data.get("ffmpeg", {}) if isinstance(data, dict) else {}
+    updated = {
+        "max_attempts": int(data.get("max_attempts", 1)),
+        "backoff_factor": float(data.get("backoff_factor", 1.0)),
+        "jitter_ms": int(data.get("jitter_ms", 0)),
+        "enabled": bool(ffmpeg_cfg.get("enabled", False)),
+        "retryable_exit_codes": list(ffmpeg_cfg.get("retryable_exit_codes", [])),
+    }
+    _FFMPEG_RETRY_CFG = updated
+    log_event("retry_config_updated", component="ffmpeg", config=updated)
+
+
+def _normalize_retry_cfg(raw: Optional[Dict[str, object]]) -> Dict[str, object]:
+    if not raw:
+        return dict(_FFMPEG_RETRY_CFG)
+    cfg = dict(raw)
+    return {
+        "max_attempts": max(1, int(cfg.get("max_attempts", _FFMPEG_RETRY_CFG["max_attempts"]))),
+        "backoff_factor": max(1.0, float(cfg.get("backoff_factor", _FFMPEG_RETRY_CFG["backoff_factor"]))),
+        "jitter_ms": max(0, int(cfg.get("jitter_ms", _FFMPEG_RETRY_CFG["jitter_ms"]))),
+        "enabled": bool(cfg.get("enabled", _FFMPEG_RETRY_CFG["enabled"])),
+        "retryable_exit_codes": list(cfg.get("retryable_exit_codes", _FFMPEG_RETRY_CFG["retryable_exit_codes"])),
+    }
+
+
+def _tail_text(text: str, limit: int = 2000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def classify_ffmpeg(stderr: str, code: int) -> Tuple[str, str]:
+    """根据 FFmpeg 输出推断错误类别与修复建议。"""
+
+    message = (stderr or "").lower()
+    if code == 127 or "command not found" in message:
+        return "no_ffmpeg", "确认已安装 FFmpeg 并在 PATH 中可用"
+    if "no such file or directory" in message or "unable to open" in message:
+        return "file_not_found", "检查输入输出路径是否正确存在"
+    if "permission denied" in message:
+        return "permission", "检查输出目录及文件权限"
+    if "no space left" in message or "disk full" in message:
+        return "disk_full", "清理磁盘空间或调整输出目录"
+    if "codec not found" in message or "unknown encoder" in message:
+        return "codec_missing", "安装所需编解码器或修改编码参数"
+    if "device or resource busy" in message or "resource temporarily unavailable" in message:
+        return "resource_busy", "确认输出文件未被占用或稍后重试"
+    if "broken pipe" in message or "ePIPE" in message:
+        return "broken_pipe", "检查上游数据流或管道写入是否中断"
+    if "connection timed out" in message or "timed out" in message:
+        return "timeout", "检查网络/IO 条件或调高超时时间"
+    if "input/output error" in message:
+        return "io_error", "检查磁盘健康状态或更换输出位置"
+    return "unknown", "查看 stderr 详情或命令参数以进一步排查"
 
 
 def ensure_ffmpeg_available(explicit_path: Optional[str] = None) -> str:
@@ -27,16 +107,91 @@ def ensure_ffmpeg_available(explicit_path: Optional[str] = None) -> str:
     return ffmpeg_path
 
 
-def run_ffmpeg(command: Sequence[str]) -> None:
-    """运行 FFmpeg 命令并输出日志。"""
+def run_ffmpeg(command: Sequence[str], *, _retry_cfg: Optional[Dict[str, object]] = None) -> None:
+    """运行 FFmpeg 命令并在失败时执行分类与重试。"""
 
-    console.log("[cyan]执行 FFmpeg：[/cyan]" + " ".join(command))
-    process = subprocess.run(command, check=False, capture_output=True, text=True)
-    if process.stdout:
-        console.log(process.stdout)
-    if process.returncode != 0:
-        console.log(f"[red]FFmpeg 执行失败：{process.stderr}[/red]")
-        raise RuntimeError(f"FFmpeg 命令失败，退出码 {process.returncode}")
+    cfg = _normalize_retry_cfg(_retry_cfg)
+    attempts = 1
+    if cfg.get("enabled"):
+        attempts = max(1, int(cfg.get("max_attempts", 1)))
+    delay = 1.0
+    cmd_str = " ".join(command)
+
+    for attempt in range(1, attempts + 1):
+        log_event("ffmpeg_start", command=cmd_str, attempt=attempt, max_attempts=attempts)
+        console.log("[cyan]执行 FFmpeg：[/cyan]" + cmd_str)
+        start = time.time()
+        try:
+            process = subprocess.run(command, check=False, capture_output=True, text=True)
+        except FileNotFoundError as err:
+            elapsed_ms = int((time.time() - start) * 1000)
+            category, hint = "no_ffmpeg", "确认已安装 FFmpeg 并在 PATH 中可用"
+            log_exception(
+                "ffmpeg_fail",
+                err,
+                command=cmd_str,
+                attempt=attempt,
+                elapsed_ms=elapsed_ms,
+                category=category,
+                hint=hint,
+            )
+            raise RuntimeError("未找到 FFmpeg 可执行文件") from err
+
+        stdout = process.stdout or ""
+        stderr = process.stderr or ""
+        code = process.returncode
+        elapsed_ms = int((time.time() - start) * 1000)
+
+        if stdout.strip():
+            console.log(stdout)
+
+        if code == 0:
+            log_event("ffmpeg_success", command=cmd_str, attempt=attempt, elapsed_ms=elapsed_ms)
+            return
+
+        console.log(f"[red]FFmpeg 执行失败：{stderr}[/red]")
+        category, hint = classify_ffmpeg(stderr, code)
+        error = RuntimeError(f"FFmpeg 命令失败，退出码 {code}")
+        log_exception(
+            "ffmpeg_fail",
+            error,
+            command=cmd_str,
+            attempt=attempt,
+            elapsed_ms=elapsed_ms,
+            category=category,
+            hint=hint,
+            code=code,
+            stderr=_tail_text(stderr),
+        )
+
+        retryable_codes = set(cfg.get("retryable_exit_codes", []))
+        retryable_categories = {"timeout", "resource_busy", "broken_pipe", "io_error"}
+        should_retry = (
+            cfg.get("enabled")
+            and attempt < attempts
+            and (code in retryable_codes or category in retryable_categories)
+        )
+
+        if should_retry:
+            jitter_ms = int(cfg.get("jitter_ms", 0))
+            jitter = random.randint(0, jitter_ms) / 1000.0 if jitter_ms else 0.0
+            sleep_seconds = delay + jitter
+            log_event(
+                "ffmpeg_retry",
+                command=cmd_str,
+                attempt=attempt,
+                next_delay_ms=int(sleep_seconds * 1000),
+                category=category,
+                hint=hint,
+                code=code,
+            )
+            time.sleep(sleep_seconds)
+            delay *= float(cfg.get("backoff_factor", 1.0))
+            continue
+
+        raise error
+
+    raise RuntimeError("FFmpeg 命令多次重试后仍失败")
 
 
 def encode_image_sequence(
@@ -165,4 +320,5 @@ __all__ = [
     "mux_audio",
     "extract_cover",
     "create_placeholder_clip",
+    "configure_ffmpeg_retry",
 ]


### PR DESCRIPTION
## Summary
- add JSONL structured logging with configurable retry settings and initialize it during config load
- wrap txt2img/img2vid Stable Diffusion calls with categorized retry logic and structured events
- classify ffmpeg failures with hints, optional retries, and surface uploader events alongside new stability documentation

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e84e9e77d48328b674755228b298db