### PR TITLE
Implement sampling fallback and unified config center

### DIFF
--- a/auto-mograph-bot/configs/default.yaml
+++ b/auto-mograph-bot/configs/default.yaml
@@ -45,6 +45,18 @@ prompts:
   max_desc_length: 120
   max_tags: 5
 
+sampling:
+  max_retries: 10
+  stats_log: true
+  fallback:
+    enabled: true
+    title: "今天也要加油"
+    description: "保持创作与节奏，见证每天的小进步。"
+    tags: ["日常", "励志", "记录"]
+    prompt_text: "清新剪贴风, 竖屏, 简约背景, 主角置中"
+  blacklist: []
+  safe_words: ["温暖", "可爱", "元气"]
+
 scheduler:
   batch_size: 1
   concurrency: 2
@@ -96,3 +108,6 @@ retry:
 
 logging:
   jsonl_path: "outputs/logs/pipeline.jsonl"
+
+profiles:
+  dir: "profiles"

--- a/auto-mograph-bot/docs/config_profiles_README.md
+++ b/auto-mograph-bot/docs/config_profiles_README.md
@@ -1,0 +1,78 @@
+# 配置中心与 Profile 使用指南
+
+本文档说明如何使用统一配置中心、抽样回退策略以及 Profile 导入/导出流程。所有示例均为纯文本 YAML，不会生成任何二进制或媒体文件。
+
+## 统一配置中心
+
+- 配置中心位于 `src/config_center/center.py`，由 `ConfigCenter` 负责加载、合并与校验配置。
+- 加载顺序：
+  1. `configs/default.yaml`
+  2. 可选的覆盖文件（例如 `configs/mvp.yaml` 或导入的 Profile）
+  3. 环境变量（通过 `.env` 或进程环境传入）
+- 配置被验证后会冻结成只读视图供 CLI 与 GUI 同时使用，防止运行时被意外修改。
+- 通过 `src/config.py` 中的 `load_config`、`get_config_center`、`get_config_view` 可以在任意模块获取一致的配置数据。
+
+## 抽样失败统计与回退
+
+`configs/default.yaml` 中新增 `sampling` 段落，用于定义抽样统计与回退策略：
+
+```yaml
+sampling:
+  max_retries: 10
+  stats_log: true
+  fallback:
+    enabled: true
+    title: "今天也要加油"
+    description: "保持创作与节奏，见证每天的小进步。"
+    tags: ["日常", "励志", "记录"]
+    prompt_text: "清新剪贴风, 竖屏, 简约背景, 主角置中"
+  blacklist: []
+  safe_words: ["温暖", "可爱", "元气"]
+```
+
+- `max_retries`：文案采样的最大尝试次数。
+- `stats_log`：为 `true` 时成功样本和回退事件都会写入 `outputs/logs/pipeline.jsonl`。
+- `fallback.enabled`：达到阈值后是否启用安全默认文案。
+- `fallback` 内的标题、描述、标签、提示词都会在需要时作为兜底内容，并自动注入 `safe_words`。
+- `blacklist`、`safe_words` 可在运行时追加，便于 GUI/CLI 统一维护。
+
+结构化日志事件：
+
+- `prompt_sample_success`：采样成功，附带统计字段。
+- `prompt_fallback_used`：触发回退，包含失败原因与最终文案。
+- `prompt_fallback_trimmed`：当兜底文案因超长被截断时记录。
+- `prompt_sample_exhausted`：达到阈值但未启用回退时的错误信息。
+
+所有日志都会写入纯文本 JSONL 文件 `outputs/logs/pipeline.jsonl`，方便后续统计。
+
+## Profile 导入与导出
+
+- `profiles.dir` 字段定义 Profile 存放目录，默认 `profiles/`。
+- GUI 配置编辑器与 CLI 均通过配置中心读写 Profile：
+  - **导出**：GUI 中点击“导出 Profile”按钮，或调用 `ConfigCenter.export_profile(name, path)`，会将当前合并后的配置保存为 `{profile: {name}, config: ...}` 结构的 YAML。
+  - **导入**：GUI 中点击“导入 Profile”，或调用 `ConfigCenter.import_profile(path)`。配置中心会将 Profile 与默认配置合并后写入 `configs/NAME.yaml`，并立即刷新全局视图。
+- 导入/导出的 Profile 均为纯文本 YAML 文件，可通过版本管理或外部工具编辑。
+
+## 在 CLI 中使用
+
+```python
+from pathlib import Path
+from src.config import load_config
+
+config = load_config(Path("configs/default.yaml"))
+print(config.video.width)
+```
+
+- `load_config` 始终走配置中心逻辑，确保 CLI、批处理脚本与 GUI 共享同一份配置。
+- 若需要查看只读配置，可调用 `from src.config import get_config_view` 获取冻结后的字典。
+
+## 在 GUI 中使用
+
+- `ui/components/views/config_editor.py` 已接入配置中心，支持配置保存前校验与 Profile 导入/导出。
+- GUI 保存配置后会立即调用配置中心刷新，使 CLI/后台任务能够读取到最新的 YAML。
+
+## 注意事项
+
+- 项目不会生成任何二进制、模型或媒体样例文件，所有配置/日志均为纯文本。
+- 导入外部 Profile 时请确认其来源可信，避免覆盖敏感字段。
+- 结构化日志文件可能包含统计数据，请在分享前做脱敏处理。

--- a/auto-mograph-bot/src/config_center/center.py
+++ b/auto-mograph-bot/src/config_center/center.py
@@ -1,0 +1,250 @@
+"""Unified configuration center for CLI and GUI components."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import yaml
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    """Load a YAML file if it exists, returning an empty dict otherwise."""
+
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fp:
+        data = yaml.safe_load(fp) or {}
+        if not isinstance(data, MutableMapping):
+            raise TypeError(f"YAML {path} must contain a mapping at the top level")
+        return dict(data)
+
+
+def _merge_dict(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge two dictionaries and return the merged result."""
+
+    result: Dict[str, Any] = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _freeze(value: Any) -> Any:
+    """Create an immutable view for the given value."""
+
+    if isinstance(value, dict):
+        frozen = {key: _freeze(inner) for key, inner in value.items()}
+        return MappingProxyType(frozen)
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _write_yaml_atomic(path: Path, data: Mapping[str, Any]) -> None:
+    """Write YAML atomically to avoid partially written files."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=str(path.parent), delete=False) as tmp:
+        yaml.safe_dump(data, tmp, allow_unicode=True, sort_keys=False)
+        temp_name = tmp.name
+    os.replace(temp_name, path)
+
+
+class ConfigCenter:
+    """Centralises configuration loading, validation and profile management."""
+
+    def __init__(self, model_cls: Optional[type[BaseModel]] = None) -> None:
+        self._model_cls = model_cls
+        self._model: Optional[BaseModel] = None
+        self._raw: Dict[str, Any] = {}
+        self._frozen: Mapping[str, Any] = MappingProxyType({})
+        self._base_paths: list[str] = ["configs/default.yaml"]
+        self._extra_paths: list[str] = []
+        self._env_path: Optional[Path] = Path(".env")
+        self._default_snapshot: Dict[str, Any] = {}
+        self._profiles_dir: Path = Path("profiles")
+
+    # ------------------------------------------------------------------
+    def load(
+        self,
+        *,
+        base_paths: Optional[Iterable[str]] = None,
+        extra_paths: Optional[Iterable[str]] = None,
+        env_path: Optional[str] = None,
+    ) -> Mapping[str, Any]:
+        """Load configuration files and environment overrides."""
+
+        if base_paths is not None:
+            self._base_paths = [str(Path(p)) for p in base_paths]
+        if extra_paths is not None:
+            self._extra_paths = [str(Path(p)) for p in extra_paths]
+        if env_path is not None:
+            self._env_path = Path(env_path)
+        elif self._env_path is None:
+            self._env_path = Path(".env")
+
+        if self._env_path and self._env_path.exists():
+            load_dotenv(self._env_path, override=False)
+
+        ordered_paths = self._base_paths + self._extra_paths
+        data: Dict[str, Any] = {}
+        for idx, path_str in enumerate(ordered_paths):
+            yaml_data = _load_yaml(Path(path_str))
+            if idx == 0:
+                self._default_snapshot = yaml_data
+            data = _merge_dict(data, yaml_data)
+
+        data = _merge_dict(data, self._build_env_override())
+        self._raw = data
+        self._frozen = _freeze(data)
+
+        if self._model_cls is not None:
+            self._model = self._model_cls.model_validate(data)
+        else:
+            self._model = None
+
+        profiles_cfg = data.get("profiles", {})
+        if isinstance(profiles_cfg, Mapping):
+            directory = profiles_cfg.get("dir")
+            if isinstance(directory, str) and directory:
+                self._profiles_dir = Path(directory)
+        self._profiles_dir.mkdir(parents=True, exist_ok=True)
+        return self.get()
+
+    # ------------------------------------------------------------------
+    def reload(self) -> Mapping[str, Any]:
+        """Reload with the last used parameters."""
+
+        return self.load(
+            base_paths=self._base_paths,
+            extra_paths=self._extra_paths,
+            env_path=str(self._env_path) if self._env_path else None,
+        )
+
+    # ------------------------------------------------------------------
+    def get(self) -> Mapping[str, Any]:
+        """Return an immutable view of the merged configuration."""
+
+        return self._frozen
+
+    # ------------------------------------------------------------------
+    def get_raw(self) -> Dict[str, Any]:
+        """Return a mutable copy of the merged configuration."""
+
+        return dict(self._raw)
+
+    # ------------------------------------------------------------------
+    def get_model(self) -> Optional[BaseModel]:
+        """Return the validated Pydantic model, if any."""
+
+        return self._model
+
+    # ------------------------------------------------------------------
+    @property
+    def profile_directory(self) -> Path:
+        """Return the directory used to store profile YAML files."""
+
+        return self._profiles_dir
+
+    # ------------------------------------------------------------------
+    def validate(self, payload: Mapping[str, Any]) -> BaseModel:
+        """Validate a configuration payload using the configured model class."""
+
+        if self._model_cls is None:
+            raise RuntimeError("ConfigCenter was initialised without a model class")
+        merged = _merge_dict(dict(self._default_snapshot), dict(payload))
+        return self._model_cls.model_validate(merged)
+
+    # ------------------------------------------------------------------
+    def export_profile(self, name: str, path: str) -> Path:
+        """Export the current configuration as a profile YAML."""
+
+        if not name:
+            raise ValueError("Profile name cannot be empty")
+        if not self._raw:
+            raise RuntimeError("Configuration has not been loaded")
+        target = Path(path)
+        payload = {
+            "profile": {
+                "name": name,
+            },
+            "config": self._raw,
+        }
+        _write_yaml_atomic(target, payload)
+        return target
+
+    # ------------------------------------------------------------------
+    def import_profile(self, path: str) -> Path:
+        """Import a profile YAML and store it under configs/NAME.yaml."""
+
+        source = Path(path)
+        if not source.exists():
+            raise FileNotFoundError(f"Profile source {source} does not exist")
+        with source.open("r", encoding="utf-8") as fp:
+            payload = yaml.safe_load(fp) or {}
+        if not isinstance(payload, Mapping):
+            raise TypeError("Imported profile must contain a mapping")
+        profile_meta = payload.get("profile", {})
+        if isinstance(profile_meta, Mapping):
+            name = str(profile_meta.get("name") or source.stem)
+        else:
+            name = source.stem
+        config_data = payload.get("config") if "config" in payload else payload
+        if not isinstance(config_data, Mapping):
+            raise TypeError("Profile config section 必须为映射类型")
+        base = self._default_snapshot or {}
+        merged = _merge_dict(base, dict(config_data))
+        target = Path("configs") / f"{name}.yaml"
+        _write_yaml_atomic(target, merged)
+
+        if str(target) not in self._extra_paths:
+            self._extra_paths = [*self._extra_paths, str(target)]
+        self.reload()
+        return target
+
+    # ------------------------------------------------------------------
+    def _build_env_override(self) -> Dict[str, Any]:
+        """Construct overrides sourced from environment variables."""
+
+        override: Dict[str, Any] = {
+            "sd": {
+                "webui_url": os.getenv("SD_WEBUI_URL"),
+                "webui_token": os.getenv("SD_WEBUI_TOKEN"),
+                "model_path": Path(os.getenv("SD_MODEL_PATH")) if os.getenv("SD_MODEL_PATH") else None,
+            },
+            "animate": {
+                "model_path": Path(os.getenv("ANIMATEDIFF_MODEL_PATH")) if os.getenv("ANIMATEDIFF_MODEL_PATH") else None,
+                "motion_module": Path(os.getenv("ANIMATEDIFF_MOTION_PATH")) if os.getenv("ANIMATEDIFF_MOTION_PATH") else None,
+            },
+            "uploader": {
+                "api_token": os.getenv("UPLOADER_API_TOKEN"),
+                "cookie_path": Path(os.getenv("UPLOADER_COOKIE_PATH")) if os.getenv("UPLOADER_COOKIE_PATH") else None,
+                "appium_server": os.getenv("APPIUM_SERVER"),
+                "device_name": os.getenv("APPIUM_DEVICE_NAME"),
+            },
+            "runtime": {
+                "seed": int(os.getenv("GLOBAL_SEED")) if os.getenv("GLOBAL_SEED") else None,
+                "dry_run": str(os.getenv("DRY_RUN", "false")).lower() == "true",
+            },
+        }
+        # Remove None values to avoid overriding explicit configuration
+        for section in list(override.keys()):
+            cleaned: Dict[str, Any] = {}
+            for key, value in override[section].items():
+                if value is not None:
+                    cleaned[key] = value
+            if cleaned:
+                override[section] = cleaned
+            else:
+                override.pop(section)
+        return override
+
+
+__all__ = ["ConfigCenter"]

--- a/auto-mograph-bot/src/runner/job.py
+++ b/auto-mograph-bot/src/runner/job.py
@@ -79,6 +79,7 @@ class GenerationJob:
             max_title=self.config.prompts.max_title_length,
             max_desc=self.config.prompts.max_desc_length,
             max_tags=self.config.prompts.max_tags,
+            sampling_cfg=self.config.raw_data.get("sampling", {}),
         )
         console.log(f"[bold cyan]选定 Prompt：[/bold cyan]{candidate.prompt}")
 

--- a/auto-mograph-bot/ui/components/views/config_editor.py
+++ b/auto-mograph-bot/ui/components/views/config_editor.py
@@ -1,8 +1,10 @@
 """YAML 配置编辑器视图。"""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
+import yaml
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import (
     QWidget,
@@ -12,40 +14,55 @@ from PySide6.QtWidgets import (
     QPushButton,
     QPlainTextEdit,
     QMessageBox,
+    QFileDialog,
 )
+
+from src.config import get_config_center
 
 from ...state import AppState
 from ...utils import yaml_io
 
 
 class ConfigEditorView(QWidget):
-    """用于浏览与编辑 YAML 配置。"""
+    """用于浏览与编辑 YAML 配置，同时支持 Profile 导入导出。"""
 
     def __init__(self, state: AppState, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self.state = state
+        self.center = get_config_center()
         self.combo = QComboBox(self)
         self.editor = QPlainTextEdit(self)
         self.save_button = QPushButton("保存", self)
         self.reload_button = QPushButton("重新加载", self)
         self.validate_button = QPushButton("校验", self)
+        self.export_button = QPushButton("导出 Profile", self)
+        self.import_button = QPushButton("导入 Profile", self)
 
         control_layout = QHBoxLayout()
         control_layout.addWidget(self.combo)
         control_layout.addWidget(self.reload_button)
         control_layout.addWidget(self.save_button)
         control_layout.addWidget(self.validate_button)
+        control_layout.addWidget(self.export_button)
+        control_layout.addWidget(self.import_button)
 
         layout = QVBoxLayout()
         layout.addLayout(control_layout)
         layout.addWidget(self.editor)
         self.setLayout(layout)
 
+        try:
+            self.center.reload()
+        except Exception:
+            # 即使加载失败也允许手工编辑，后续操作会提示错误。
+            pass
         self._populate_files()
         self.combo.currentTextChanged.connect(self.load_selected)
         self.reload_button.clicked.connect(self.on_reload)
         self.save_button.clicked.connect(self.on_save)
         self.validate_button.clicked.connect(self.on_validate)
+        self.export_button.clicked.connect(self.on_export_profile)
+        self.import_button.clicked.connect(self.on_import_profile)
         if self.combo.count() > 0:
             self.load_selected(self.combo.currentText())
 
@@ -57,6 +74,10 @@ class ConfigEditorView(QWidget):
     def refresh(self) -> None:
         """刷新文件列表并重新加载当前文件。"""
 
+        try:
+            self.center.reload()
+        except Exception:
+            pass
         current = self.combo.currentText()
         self._populate_files()
         if current:
@@ -86,10 +107,18 @@ class ConfigEditorView(QWidget):
         if not path:
             return
         try:
+            data = yaml.safe_load(self.editor.toPlainText() or "") or {}
+            if not isinstance(data, dict):
+                raise ValueError("配置文件必须是映射结构")
+            self.center.validate(data)
             with open(path, "w", encoding="utf-8") as handle:
-                handle.write(self.editor.toPlainText())
+                yaml.safe_dump(data, handle, allow_unicode=True, sort_keys=False)
+            self.center.reload()
         except OSError as exc:
             QMessageBox.critical(self, "写入失败", str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001 - 直接反馈错误
+            QMessageBox.critical(self, "保存失败", str(exc))
             return
         QMessageBox.information(self, "成功", "配置已保存")
 
@@ -100,13 +129,49 @@ class ConfigEditorView(QWidget):
             return
         try:
             content = yaml_io.load_yaml_file(path)
-            if not self.state.current_profile:
-                raise ValueError("当前没有激活的 Profile")
-            yaml_io.validate_yaml_with_model(content, type(self.state.current_profile))
+            self.center.validate(content)
         except Exception as exc:  # noqa: BLE001 - 直接反馈错误
             QMessageBox.warning(self, "校验失败", str(exc))
             return
         QMessageBox.information(self, "校验", "文件结构有效")
+
+    @Slot()
+    def on_export_profile(self) -> None:
+        default_name = self.state.current_profile.name if self.state.current_profile else "profile"
+        default_path = self.center.profile_directory / f"{default_name}.yaml"
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "导出 Profile",
+            str(default_path),
+            "YAML Files (*.yaml)",
+        )
+        if not path:
+            return
+        name = Path(path).stem
+        try:
+            self.center.export_profile(name, path)
+        except Exception as exc:  # noqa: BLE001
+            QMessageBox.critical(self, "导出失败", str(exc))
+            return
+        QMessageBox.information(self, "导出", f"Profile 已保存到 {path}")
+
+    @Slot()
+    def on_import_profile(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "导入 Profile",
+            str(self.center.profile_directory),
+            "YAML Files (*.yaml)",
+        )
+        if not path:
+            return
+        try:
+            target = self.center.import_profile(path)
+        except Exception as exc:  # noqa: BLE001
+            QMessageBox.critical(self, "导入失败", str(exc))
+            return
+        QMessageBox.information(self, "导入", f"Profile 已同步到 {target}")
+        self.refresh()
 
 
 __all__ = ["ConfigEditorView"]


### PR DESCRIPTION
## Summary
- add a centralized configuration loader with profile import/export helpers shared by CLI and GUI
- enhance prompt sampling to log detailed failure stats and fall back to configurable safe copy when retries are exhausted
- update the GUI config editor, default configuration, and documentation to describe the unified workflow and fallback settings

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e85869c05c832885611362202b5790